### PR TITLE
fix: make hardcoded strings translatable

### DIFF
--- a/js/src/forum/components/TwoFactorGrid.js
+++ b/js/src/forum/components/TwoFactorGrid.js
@@ -58,12 +58,12 @@ export default class TwoFactorGrid extends Component {
       'backupCodes',
       <TwoFactorGridItem
         icon="fas fa-key"
-        title="Backup Codes Remaining:"
+        title={app.translator.trans('ianm-twofactor.forum.security.backup_codes_remaining')}
         value={this.backupCodesRemaining}
         // action={
         //   this.backupCodesRemaining < 2 ? (
         //     <Button className="Button Button--primary" onclick={this.generateBackupCodes.bind(this)}>
-        //       Generate More
+        //       {app.translator.trans('ianm-twofactor.forum.security.generate_backup_codes_button')}
         //     </Button>
         //   ) : null
         // }

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -37,6 +37,7 @@ ianm-twofactor:
       backup_codes: Your Backup Codes
       backup_codes_instruction: Please save these codes in a secure place. They can be used to access your account if you lose your primary authentication method. They will not be displayed again.
       saved_backup_codes_button: I've saved these codes
+      backup_codes_remaining: "Backup Codes Remaining:"
       two_factor_enabled_confirmation: Two-Factor Authentication has been successfully enabled for your account.
       ok_button: Ok
       confirm_disable_2fa_title: Confirm Disabling Two-Factor Authentication
@@ -61,6 +62,9 @@ ianm-twofactor:
         Two-Factor Authentication has been {type} for your account on {forum_url}.
 
         If you initiated this action, no further steps are necessary. If you did not authorize this change, please contact the forum administrators immediately.
+    status_type:
+      enabled: enabled
+      disabled: disabled
   views:
     reset_password:
       two_factor_token_label: 2FA Token

--- a/src/Notification/TwoFactorStatusChangedBlueprint.php
+++ b/src/Notification/TwoFactorStatusChangedBlueprint.php
@@ -67,7 +67,7 @@ class TwoFactorStatusChangedBlueprint implements BlueprintInterface, MailableInt
     public function getEmailSubject(TranslatorInterface $translator): string
     {
         return $translator->trans('ianm-twofactor.email.subject.status_changed', [
-            '{type}' => $this->type(),
+            '{type}' => $translator->trans('ianm-twofactor.email.status_type.' . $this->type()),
         ]);
     }
 }

--- a/src/Notification/TwoFactorStatusChangedBlueprint.php
+++ b/src/Notification/TwoFactorStatusChangedBlueprint.php
@@ -67,7 +67,7 @@ class TwoFactorStatusChangedBlueprint implements BlueprintInterface, MailableInt
     public function getEmailSubject(TranslatorInterface $translator): string
     {
         return $translator->trans('ianm-twofactor.email.subject.status_changed', [
-            '{type}' => $translator->trans('ianm-twofactor.email.status_type.' . $this->type()),
+            '{type}' => $translator->trans('ianm-twofactor.email.status_type.'.$this->type()),
         ]);
     }
 }

--- a/views/email/status_changed.blade.php
+++ b/views/email/status_changed.blade.php
@@ -1,5 +1,5 @@
 {!! $translator->trans('ianm-twofactor.email.body.status_changed', [
     '{recipient_display_name}' => $user->display_name,
     '{forum_url}' => $url->to('forum')->base(),
-    'type' => $blueprint->type()
+    '{type}' => $translator->trans('ianm-twofactor.email.status_type.' . $blueprint->type())
 ]) !!}

--- a/views/email/status_changed.blade.php
+++ b/views/email/status_changed.blade.php
@@ -1,5 +1,5 @@
 {!! $translator->trans('ianm-twofactor.email.body.status_changed', [
     '{recipient_display_name}' => $user->display_name,
     '{forum_url}' => $url->to('forum')->base(),
-    '{type}' => $translator->trans('ianm-twofactor.email.status_type.' . $blueprint->type())
+    '{type}' => $translator->trans('ianm-twofactor.email.status_type.'.$blueprint->type())
 ]) !!}


### PR DESCRIPTION
Added translations for backup codes and 2FA status email notifications.