### PR TITLE
fix: PHP 8.0 causes errors with 3rd party library. Begin adding tests. Address PHPStan

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,7 +7,7 @@ jobs:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
     with:
       enable_backend_testing: true
-      enable_phpstan: true,
+      enable_phpstan: true
       php_versions: '["8.0", "8.1", "8.2"]'
 
       backend_directory: .

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,6 @@ jobs:
     with:
       enable_backend_testing: true
       enable_phpstan: true
-      php_versions: '["8.0", "8.1", "8.2"]'
+      php_versions: '["8.1", "8.2"]'
 
       backend_directory: .

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
     with:
-      enable_backend_testing: false
+      enable_backend_testing: true
       enable_phpstan: true,
       php_versions: '["8.0", "8.1", "8.2"]'
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A [Flarum](http://flarum.org) extension. 2FA for Flarum
 
+## Requirements
+
+This extension requires a minimum of PHP 8.1, due to a 3rd party library constraint.
+
 ## Features
 
 - Enforces `admin` accounts to have 2FA enabled for increased security

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.0",
         "flarum/core": "^1.8.3",
-        "spomky-labs/otphp": "^11.2",
+        "spomky-labs/otphp": "^10.0 || ^11.2",
         "endroid/qr-code": "^4.8"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "forum": "https://discuss.flarum.org/d/33339"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "flarum/core": "^1.8.3",
-        "spomky-labs/otphp": "^10.0 || ^11.2",
+        "spomky-labs/otphp": "^11.2",
         "endroid/qr-code": "^4.8"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "php": "^8.0",
-        "flarum/core": "^1.8.0",
+        "flarum/core": "^1.8.3",
         "spomky-labs/otphp": "^11.2",
         "endroid/qr-code": "^4.8"
     },

--- a/extend.php
+++ b/extend.php
@@ -26,14 +26,14 @@ use IanM\TwoFactor\OAuth\TwoFactorOAuthCheck;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__ . '/js/dist/forum.js')
-        ->css(__DIR__ . '/less/forum.less'),
+        ->js(__DIR__.'/js/dist/forum.js')
+        ->css(__DIR__.'/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__ . '/js/dist/admin.js')
-        ->css(__DIR__ . '/less/admin.less'),
+        ->js(__DIR__.'/js/dist/admin.js')
+        ->css(__DIR__.'/less/admin.less'),
 
-    new Extend\Locales(__DIR__ . '/locale'),
+    new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\Model(Group::class))->cast('tfa_required', 'bool'),
 
@@ -89,7 +89,7 @@ return [
         ->listen(GroupSaving::class, Listener\SaveGroup2FASetting::class),
 
     (new Extend\View())
-        ->namespace('ianm-two-factor', __DIR__ . '/views'),
+        ->namespace('ianm-two-factor', __DIR__.'/views'),
 
     (new Extend\Settings())
         ->default('ianm-twofactor.admin.settings.forum_logo_qr', true)

--- a/extend.php
+++ b/extend.php
@@ -26,14 +26,14 @@ use IanM\TwoFactor\OAuth\TwoFactorOAuthCheck;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__.'/js/dist/forum.js')
-        ->css(__DIR__.'/less/forum.less'),
+        ->js(__DIR__ . '/js/dist/forum.js')
+        ->css(__DIR__ . '/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__.'/js/dist/admin.js')
-        ->css(__DIR__.'/less/admin.less'),
+        ->js(__DIR__ . '/js/dist/admin.js')
+        ->css(__DIR__ . '/less/admin.less'),
 
-    new Extend\Locales(__DIR__.'/locale'),
+    new Extend\Locales(__DIR__ . '/locale'),
 
     (new Extend\Model(Group::class))->cast('tfa_required', 'bool'),
 
@@ -89,16 +89,16 @@ return [
         ->listen(GroupSaving::class, Listener\SaveGroup2FASetting::class),
 
     (new Extend\View())
-        ->namespace('ianm-two-factor', __DIR__.'/views'),
+        ->namespace('ianm-two-factor', __DIR__ . '/views'),
 
     (new Extend\Settings())
         ->default('ianm-twofactor.admin.settings.forum_logo_qr', true)
         ->default('ianm-twofactor.admin.settings.forum_logo_qr_width', 100),
 
     (new Extend\Conditional())
-        ->whenExtensionEnabled('fof-oauth', [
-            class_exists(\FoF\Extend\Extend\OAuthController::class) ? (new \FoF\Extend\Extend\OAuthController())
-                ->afterOAuthSuccess(TwoFactorOAuthCheck::class) : null,
+        ->whenExtensionEnabled('fof-oauth', fn () => [
+            (new \FoF\Extend\Extend\OAuthController())
+                ->afterOAuthSuccess(TwoFactorOAuthCheck::class),
 
             (new Extend\Routes('forum'))
                 ->get('/twofactor/oauth/verify', 'twoFactor.oauth', Api\Controller\TwoFactorOAuthController::class)

--- a/src/Api/Controller/DisableTwoFactorController.php
+++ b/src/Api/Controller/DisableTwoFactorController.php
@@ -33,6 +33,13 @@ class DisableTwoFactorController implements RequestHandlerInterface
     {
     }
 
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     * 
+     * @throws PermissionDeniedException
+     * @throws ModelNotFoundException
+     */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $actor = RequestUtil::getActor($request);
@@ -51,7 +58,7 @@ class DisableTwoFactorController implements RequestHandlerInterface
         }
 
         if (! $this->twoFactorActive($user)) {
-            return new ModelNotFoundException();
+            throw new ModelNotFoundException();
         }
 
         $user->twoFactor->delete();

--- a/src/Api/Controller/DisableTwoFactorController.php
+++ b/src/Api/Controller/DisableTwoFactorController.php
@@ -36,7 +36,7 @@ class DisableTwoFactorController implements RequestHandlerInterface
     /**
      * @param ServerRequestInterface $request
      * @return ResponseInterface
-     * 
+     *
      * @throws PermissionDeniedException
      * @throws ModelNotFoundException
      */

--- a/src/Contracts/TotpInterface.php
+++ b/src/Contracts/TotpInterface.php
@@ -17,7 +17,7 @@ interface TotpInterface
 {
     public function createSecret(): string;
 
-    public function getProvisioningUri(string $label): string;
+    public function getProvisioningUri(string $label, string $secret = null): string;
 
     public function verify(string $secret, string $inputCode, User $user): bool;
 }

--- a/src/Model/TwoFactor.php
+++ b/src/Model/TwoFactor.php
@@ -16,6 +16,15 @@ use Flarum\Group\Group;
 use Flarum\User\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $secret
+ * @property string $backup_codes
+ * @property bool $is_active
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
 class TwoFactor extends AbstractModel
 {
     /**

--- a/src/Services/OtpWrapper.php
+++ b/src/Services/OtpWrapper.php
@@ -59,7 +59,7 @@ class OtpWrapper implements TotpInterface
      * @param non-empty-string $secret
      * @param non-empty-string $inputCode
      * @param User $user
-     * @return boolean
+     * @return bool
      */
     public function verify(string $secret, string $inputCode, User $user): bool
     {

--- a/src/Services/OtpWrapper.php
+++ b/src/Services/OtpWrapper.php
@@ -26,6 +26,9 @@ class OtpWrapper implements TotpInterface
         $this->totp->setIssuer($this->settings->get('forum_title'));
     }
 
+    /**
+     * @param non-empty-string $label
+     */
     public function setLabel(string $label): void
     {
         $this->totp->setLabel($label);
@@ -36,6 +39,11 @@ class OtpWrapper implements TotpInterface
         return $this->totp->getSecret();
     }
 
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string|null $secret
+     * @return string
+     */
     public function getProvisioningUri(string $label, string $secret = null): string
     {
         if (! empty($secret)) {
@@ -47,6 +55,12 @@ class OtpWrapper implements TotpInterface
         return $this->totp->getProvisioningUri();
     }
 
+    /**
+     * @param non-empty-string $secret
+     * @param non-empty-string $inputCode
+     * @param User $user
+     * @return boolean
+     */
     public function verify(string $secret, string $inputCode, User $user): bool
     {
         $this->totp = $this->totp->createFromSecret($secret);
@@ -59,6 +73,10 @@ class OtpWrapper implements TotpInterface
         return $this->backupCodes->validateBackupCode($user, $inputCode);
     }
 
+    /**
+     * @param non-empty-string $secret
+     * @return void
+     */
     private function createFromSecret(string $secret): void
     {
         $this->totp = TOTP::create($secret);

--- a/src/Trait/TwoFactorAuthenticationTrait.php
+++ b/src/Trait/TwoFactorAuthenticationTrait.php
@@ -18,7 +18,7 @@ use IanM\TwoFactor\Model\TwoFactor;
 trait TwoFactorAuthenticationTrait
 {
     protected TotpInterface $totp;
-    
+
     protected function twoFactorActive(User &$user): bool
     {
         if ($user->isGuest()) {

--- a/src/Trait/TwoFactorAuthenticationTrait.php
+++ b/src/Trait/TwoFactorAuthenticationTrait.php
@@ -12,10 +12,13 @@
 namespace IanM\TwoFactor\Trait;
 
 use Flarum\User\User;
+use IanM\TwoFactor\Contracts\TotpInterface;
 use IanM\TwoFactor\Model\TwoFactor;
 
 trait TwoFactorAuthenticationTrait
 {
+    protected TotpInterface $totp;
+    
     protected function twoFactorActive(User &$user): bool
     {
         if ($user->isGuest()) {

--- a/tests/integration/api/CurrentUserSerializerTest.php
+++ b/tests/integration/api/CurrentUserSerializerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\TwoFactor\tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class CurrentUserSerializerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('ianm-twofactor');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_includes_two_factor_properties_in_current_user_attributes()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/2', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('twoFactorEnabled', $json['data']['attributes']);
+        $this->assertArrayHasKey('canDisable2FA', $json['data']['attributes']);
+        $this->assertArrayHasKey('mustEnable2FA', $json['data']['attributes']);
+        $this->assertArrayHasKey('backupCodesRemaining', $json['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_include_two_factor_properties_in_current_user_attributes_if_user_is_different()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/1', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('twoFactorEnabled', $json['data']['attributes']);
+        $this->assertArrayNotHasKey('canDisable2FA', $json['data']['attributes']);
+        $this->assertArrayNotHasKey('mustEnable2FA', $json['data']['attributes']);
+        $this->assertArrayNotHasKey('backupCodesRemaining', $json['data']['attributes']);
+    }
+}

--- a/tests/integration/api/CurrentUserSerializerTest.php
+++ b/tests/integration/api/CurrentUserSerializerTest.php
@@ -17,7 +17,7 @@ use Flarum\Testing\integration\TestCase;
 class CurrentUserSerializerTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
-    
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/integration/api/ForumSerializerTest.php
+++ b/tests/integration/api/ForumSerializerTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace IanM\TwoFactor\tests\integration\api;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
@@ -8,7 +17,7 @@ use Flarum\Testing\integration\TestCase;
 class ForumSerializerTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
-    
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/integration/api/ForumSerializerTest.php
+++ b/tests/integration/api/ForumSerializerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace IanM\TwoFactor\tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ForumSerializerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('ianm-twofactor');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_includes_logo_url_in_forum_attributes_if_user_is_admin()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayHasKey('ianm_twofactor_logoUrl', $json['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_include_logo_url_in_forum_attributes_if_user_is_not_admin()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api', [
+                'authenticatedAs' => 2,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('ianm_twofactor_logoUrl', $json['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_include_logo_url_in_forum_attributes_if_user_is_not_authenticated()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api')
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertArrayNotHasKey('ianm_twofactor_logoUrl', $json['data']['attributes']);
+    }
+}


### PR DESCRIPTION
- fix: conditional extender now uses callable
- fix: remaining PHPStan errors
- chore: Require PHP 8.1 or above
