### PR TITLE
feat: support gdpr, add basic login tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
     "require-dev": {
         "flarum/testing": "^1.8.0",
         "fof/oauth": "*",
-        "flarum/phpstan": "^1.8"
+        "flarum/phpstan": "^1.8",
+        "blomstra/gdpr": "@beta"
     }
 }

--- a/extend.php
+++ b/extend.php
@@ -11,6 +11,7 @@
 
 namespace IanM\TwoFactor;
 
+use Blomstra\Gdpr\Extend\UserData;
 use Flarum\Api\Controller\ShowUserController;
 use Flarum\Api\Serializer\BasicUserSerializer;
 use Flarum\Api\Serializer\CurrentUserSerializer;
@@ -35,7 +36,8 @@ return [
 
     new Extend\Locales(__DIR__.'/locale'),
 
-    (new Extend\Model(Group::class))->cast('tfa_required', 'bool'),
+    (new Extend\Model(Group::class))
+        ->cast('tfa_required', 'bool'),
 
     (new Extend\Routes('api'))
         ->get('/users/{id}/twofactor/qrcode', 'user.twofactor.get-qr', Api\Controller\ShowQrCodeController::class)
@@ -59,9 +61,6 @@ return [
 
     (new Extend\Model(User::class))
         ->hasOne('twoFactor', TwoFactor::class, 'user_id'),
-
-    (new Extend\Model(TwoFactor::class))
-        ->cast('is_active', 'bool'),
 
     (new Extend\ApiSerializer(CurrentUserSerializer::class))
         ->attributes(Api\AddCurrentUserAttributes::class),
@@ -103,6 +102,10 @@ return [
             (new Extend\Routes('forum'))
                 ->get('/twofactor/oauth/verify', 'twoFactor.oauth', Api\Controller\TwoFactorOAuthController::class)
                 ->post('/twofactor/oauth/verify', 'twoFactor.oauth.verify', Api\Controller\TwoFactorOAuthVerifyController::class),
+        ])
+        ->whenExtensionEnabled('blomstra-gdpr', fn () => [
+            (new UserData())
+                ->addType(Data\TwoFactorData::class),
         ]),
 
 ];

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -70,3 +70,10 @@ ianm-twofactor:
       two_factor_token_label: 2FA Token
     two_factor_token:
       submit_button: Submit Token
+
+blomstra-gdpr:
+  lib:
+    data:
+      twofactordata:
+        export_description: Exports 2FA status and encrypted backup codes.
+        delete_description: Deletes all data related to 2FA.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,8 @@ parameters:
   # The level will be increased in Flarum 2.0
   level: 5
   paths:
-    - src
     - extend.php
+    - src
   excludePaths:
     - *.blade.php
   checkMissingIterableValueType: false

--- a/src/Data/TwoFactorData.php
+++ b/src/Data/TwoFactorData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace IanM\TwoFactor\Data;
+
+use Blomstra\Gdpr\Data\Type;
+use IanM\TwoFactor\Model\TwoFactor;
+use Illuminate\Support\Arr;
+
+class TwoFactorData extends Type
+{
+    public function export(): ?array
+    {
+        $record = TwoFactor::query()
+            ->where('user_id', $this->user->id)
+            ->first();
+
+        if ($record) {
+            return ["2fa/{$this->user->id}.json" => $this->encodeForExport($this->sanitize($record))];
+        }
+
+        return [];
+    }
+
+    protected function sanitize(TwoFactor $twoFactor): array
+    {
+        return Arr::except($twoFactor->toArray(), ['id', 'user_id', 'secret']);
+    }
+
+    public static function anonymizeDescription(): string
+    {
+        return self::deleteDescription();
+    }
+
+    public function anonymize(): void
+    {
+        $this->delete();
+    }
+
+    public function delete(): void
+    {
+        TwoFactor::query()
+            ->where('user_id', $this->user->id)
+            ->delete();
+    }
+}

--- a/src/Data/TwoFactorData.php
+++ b/src/Data/TwoFactorData.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace IanM\TwoFactor\Data;
 
 use Blomstra\Gdpr\Data\Type;

--- a/src/Trait/TwoFactorAuthenticationTrait.php
+++ b/src/Trait/TwoFactorAuthenticationTrait.php
@@ -19,20 +19,15 @@ trait TwoFactorAuthenticationTrait
 {
     protected TotpInterface $totp;
 
-    protected function twoFactorActive(User &$user): bool
+    protected function twoFactorActive(User &$user): ?bool
     {
         if ($user->isGuest()) {
             return false;
         }
 
-        $twoFactor = $user->twoFactor ?? TwoFactor::getForUser($user);
-        $active = $twoFactor->is_active;
-
-        if ($active === null) {
-            $active = false;
-        }
-
-        return $active;
+        /** @var TwoFactor|null $twoFactor */
+        $twoFactor = $user->twoFactor;
+        return $twoFactor?->is_active;
     }
 
     protected function retrieveTwoFactorTokenFrom(?string $source): ?string

--- a/src/Trait/TwoFactorAuthenticationTrait.php
+++ b/src/Trait/TwoFactorAuthenticationTrait.php
@@ -27,6 +27,7 @@ trait TwoFactorAuthenticationTrait
 
         /** @var TwoFactor|null $twoFactor */
         $twoFactor = $user->twoFactor;
+
         return $twoFactor?->is_active;
     }
 

--- a/tests/integration/api/CurrentUserSerializerTest.php
+++ b/tests/integration/api/CurrentUserSerializerTest.php
@@ -11,6 +11,7 @@
 
 namespace IanM\TwoFactor\tests\integration\api;
 
+use Carbon\Carbon;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 
@@ -28,6 +29,9 @@ class CurrentUserSerializerTest extends TestCase
             'users' => [
                 $this->normalUser(),
             ],
+            'two_factor' => [
+                ['id' => 1, 'user_id' => 1, 'secret' => 'abcdef123456', 'backup_codes' => '["$2y$10$8UDXx3Fbx\/K9uKHs.4wq8OIP3\/q.0PghYhX\/v9ckHmvXwY2yUI.IC","$2y$10$KWw6OT18AMWa\/T1NcS1hjOiMfuzq45L1KKsFUBXAIjKTsvXJcUEOW"]', 'is_active' => true, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()]
+            ]
         ]);
     }
 
@@ -71,5 +75,26 @@ class CurrentUserSerializerTest extends TestCase
         $this->assertArrayNotHasKey('canDisable2FA', $json['data']['attributes']);
         $this->assertArrayNotHasKey('mustEnable2FA', $json['data']['attributes']);
         $this->assertArrayNotHasKey('backupCodesRemaining', $json['data']['attributes']);
+    }
+
+    /**
+     * @test
+     */
+    public function two_factor_is_enabled_for_given_user_and_returns_correct_properties()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/users/1', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertTrue($json['data']['attributes']['twoFactorEnabled']);
+        $this->assertFalse($json['data']['attributes']['canDisable2FA']);
+        $this->assertFalse($json['data']['attributes']['mustEnable2FA']);
+        $this->assertEquals(2, $json['data']['attributes']['backupCodesRemaining']);
     }
 }

--- a/tests/integration/api/LoginTest.php
+++ b/tests/integration/api/LoginTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace IanM\TwoFactor\tests\integration\api;
+
+use Carbon\Carbon;
+use Flarum\Extend;
+use Flarum\Http\AccessToken;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+    
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extend(
+            (new Extend\Csrf)->exemptRoute('login')
+        );
+
+        $this->extension('ianm-twofactor');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'normal2', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'email' => 'normal2@machine.local', 'is_email_confirmed' => 1,
+                ]
+            ],
+            'two_factor' => [
+                ['id' => 1, 'user_id' => 2, 'secret' => 'OIZ2R42HL2ZNUJNJU72P4EK26CQSD5JLEC7AVH7BCBJKRCUBUPLHXQ4TCAYVFZPDAGH3QDPHWABLMT36QAKTIFPNL5NKTR2BGVIY3GY', 'backup_codes' => '["$2y$10$8UDXx3Fbx\/K9uKHs.4wq8OIP3\/q.0PghYhX\/v9ckHmvXwY2yUI.IC","$2y$10$KWw6OT18AMWa\/T1NcS1hjOiMfuzq45L1KKsFUBXAIjKTsvXJcUEOW"]', 'is_active' => true, 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()]
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_require_2fa_token_if_2fa_is_not_enabled()
+    {
+        $response = $this->send(
+            $this->request('POST', '/login', [
+                'json' => [
+                    'identification' => 'normal2',
+                    'password' => 'too-obscure',
+                ],
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // The response body should contain the user ID...
+        $body = (string) $response->getBody();
+        $this->assertJson($body);
+
+        $data = json_decode($body, true);
+        $this->assertEquals(3, $data['userId']);
+
+        // ...and an access token belonging to this user.
+        $token = $data['token'];
+        $this->assertEquals(3, AccessToken::whereToken($token)->firstOrFail()->user_id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_2fa_token_if_2fa_is_enabled()
+    {
+        $response = $this->send(
+            $this->request('POST', '/login', [
+                'json' => [
+                    'identification' => 'normal',
+                    'password' => 'too-obscure',
+                ],
+            ])
+        );
+
+        $this->assertEquals(422, $response->getStatusCode());
+
+        $body = (string) $response->getBody();
+        $this->assertJson($body);
+
+        $data = json_decode($body, true);
+        $this->assertEquals('validation_error', $data['errors'][0]['code']);
+        $this->assertEquals('two_factor_required', $data['errors'][0]['detail']);
+        $this->assertEquals('/data/attributes/twoFactorToken', $data['errors'][0]['source']['pointer']);
+    }
+
+    // TODO: Add tests for 2FA token validation, backup codes, etc
+}

--- a/tests/integration/api/LoginTest.php
+++ b/tests/integration/api/LoginTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
 namespace IanM\TwoFactor\tests\integration\api;
 
 use Carbon\Carbon;
@@ -11,7 +20,7 @@ use Flarum\Testing\integration\TestCase;
 class LoginTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
-    
+
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
Requires `0.1.0-beta.18` or higher of `blomstra/gdpr`, if export/anonymization features are needed