### PR TITLE
Improve confirm code input UX for easier typing

### DIFF
--- a/js/src/forum/components/TwoFactorEnableModal.js
+++ b/js/src/forum/components/TwoFactorEnableModal.js
@@ -102,10 +102,14 @@ export default class TwoFactorEnableModal extends Modal {
               <form onsubmit={this.onSubmit.bind(this)}>
                 <div className="Form-group">
                   <input
+                    type="text"
                     className="FormControl"
                     name="token"
                     bidi={this.token}
                     placeholder={app.translator.trans('ianm-twofactor.forum.security.enter_token')}
+                    inputmode="numeric"
+                    pattern="[0-9]*"
+                    autocomplete="one-time-code"
                   />
                 </div>
                 <div className="Form-group">

--- a/js/src/forum/extendLogInModal.js
+++ b/js/src/forum/extendLogInModal.js
@@ -24,6 +24,9 @@ export default function extendLogInModal() {
             placeholder={app.translator.trans('ianm-twofactor.forum.log_in.two_factor_placeholder')}
             value={this.twoFactorToken()}
             disabled={this.loading}
+            inputmode="numeric"
+            pattern="[0-9]*"
+            autocomplete="one-time-code"
             oninput={(e) => {
               this.twoFactorToken(e.currentTarget.value);
 


### PR DESCRIPTION
Improve user experience when typing confirm code by using `inputmode="numeric` to ensure the number keyboard layout is shown

- Numeric keypad on mobile: Convenient code entry with `inputmode="numeric"`.
- Prevent typos: Accurate input with `pattern="[0-9]*".`
- Potential autocomplete: Streamlined logins with `autocomplete="one-time-code"`.