### PR TITLE
[1.x] feat: add extender to disable 2FA for specific OAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,38 @@ TODO
 
 ##### Admin user list status icon
 ![userlist](https://github.com/imorland/flarum-ext-twofactor/assets/16573496/9c1a58c9-919b-4552-ad1f-f022a5240f17)
+## Extensibility
+
+### Disabling 2FA for specific OAuth providers
+
+If you are building an extension that integrates with `fof/oauth` and want certain providers to bypass the 2FA challenge entirely, use the `TwoFactor` extender in your extension's `extend.php`. Wrap it in a `Conditional` so it only activates when `ianm/twofactor` is enabled:
+
+```php
+use Flarum\Extend\Conditional;
+use IanM\TwoFactor\Extend\TwoFactor;
+
+return [
+    // ...
+    (new Conditional())
+        ->whenExtensionEnabled('ianm-twofactor', fn () => [
+            (new TwoFactor())->disable('my-oauth-provider'),
+        ]),
+];
+```
+
+The provider name must match the string identifier used when registering the provider with `fof/oauth` (e.g. `'github'`, `'google'`, `'discord'`). Multiple providers can be chained:
+
+```php
+(new Conditional())
+    ->whenExtensionEnabled('ianm-twofactor', fn () => [
+        (new TwoFactor())
+            ->disable('github')
+            ->disable('google'),
+    ]),
+```
+
+> **Note:** This only bypasses the OAuth 2FA interception. Users who log in directly (username + password) are unaffected and will still be required to complete 2FA if it is enabled on their account.
+
 ## Links
 
 - [Packagist](https://packagist.org/packages/ianm/twofactor)

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
                 "backgroundColor": "#0072e3"
             },
             "optional-dependencies": [
-                "blomstra/turnstile"
+                "blomstra/turnstile",
+                "flectar/flarum-turnstile"
             ]
         },
         "flarum-cli": {
@@ -95,7 +96,7 @@
         "flarum/testing": "^1.8.0",
         "fof/oauth": "*",
         "flarum/phpstan": "^1.8",
-        "flarum/gdpr": "dev-main",
+        "flarum/gdpr": "^1.8",
         "sycho/flarum-private-facade": "^0.1.16",
         "blomstra/turnstile": "*",
         "flectar/flarum-turnstile": "*"

--- a/src/Extend/TwoFactor.php
+++ b/src/Extend/TwoFactor.php
@@ -27,7 +27,7 @@ class TwoFactor implements ExtenderInterface
         return $this;
     }
 
-    public function extend(Container $container, Extension $extension = null): void
+    public function extend(Container $container, ?Extension $extension = null): void
     {
         $container->extend(
             DisabledProviderRegistry::class,

--- a/src/Extend/TwoFactor.php
+++ b/src/Extend/TwoFactor.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\TwoFactor\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
+use Illuminate\Contracts\Container\Container;
+
+class TwoFactor implements ExtenderInterface
+{
+    private array $disabledProviders = [];
+
+    public function disable(string $provider): static
+    {
+        $this->disabledProviders[] = $provider;
+
+        return $this;
+    }
+
+    public function extend(Container $container, Extension $extension = null): void
+    {
+        $container->extend(
+            DisabledProviderRegistry::class,
+            function (DisabledProviderRegistry $registry) {
+                foreach ($this->disabledProviders as $provider) {
+                    $registry->disable($provider);
+                }
+
+                return $registry;
+            }
+        );
+    }
+}

--- a/src/OAuth/DisabledProviderRegistry.php
+++ b/src/OAuth/DisabledProviderRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\TwoFactor\OAuth;
+
+class DisabledProviderRegistry
+{
+    private array $disabled = [];
+
+    public function disable(string $provider): void
+    {
+        $this->disabled[] = $provider;
+    }
+
+    public function isDisabled(string $provider): bool
+    {
+        return in_array($provider, $this->disabled, true);
+    }
+}

--- a/src/OAuth/TwoFactorOAuthCheck.php
+++ b/src/OAuth/TwoFactorOAuthCheck.php
@@ -27,8 +27,11 @@ class TwoFactorOAuthCheck
 {
     use TwoFactorAuthenticationTrait;
 
-    public function __construct(protected TotpInterface $totp, protected UrlGenerator $url)
-    {
+    public function __construct(
+        protected TotpInterface $totp,
+        protected UrlGenerator $url,
+        protected DisabledProviderRegistry $disabledProviders,
+    ) {
     }
 
     public function __invoke(ServerRequestInterface $request, AccessTokenInterface $token, ResourceOwnerInterface $resourceOwner, string $provider)
@@ -36,6 +39,10 @@ class TwoFactorOAuthCheck
         $user = $this->getUserFromProvider($provider, $resourceOwner);
 
         if (! $user) {
+            return;
+        }
+
+        if ($this->disabledProviders->isDisabled($provider)) {
             return;
         }
 

--- a/src/Provider/TwoFactorServiceProvider.php
+++ b/src/Provider/TwoFactorServiceProvider.php
@@ -13,6 +13,7 @@ namespace IanM\TwoFactor\Provider;
 
 use Flarum\Foundation\AbstractServiceProvider;
 use IanM\TwoFactor\Contracts\TotpInterface;
+use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
 use IanM\TwoFactor\Services\BackupCodeGenerator;
 use IanM\TwoFactor\Services\OtpWrapper;
 use IanM\TwoFactor\Services\QrCodeGenerator;
@@ -26,6 +27,7 @@ class TwoFactorServiceProvider extends AbstractServiceProvider
         $this->container->bind(QrCodeGenerator::class);
         $this->container->bind(BackupCodeGenerator::class);
         $this->container->bind(TwoFactorRestrictor::class);
+        $this->container->singleton(DisabledProviderRegistry::class);
     }
 
     public function boot()


### PR DESCRIPTION
## Summary

- Adds `IanM\TwoFactor\Extend\TwoFactor` extender with a `->disable(string $provider)` method
- Adds `DisabledProviderRegistry` singleton to hold the list of exempt providers
- `TwoFactorOAuthCheck` now checks the registry and skips the 2FA challenge for exempt providers
- Documents usage in README with `Conditional` wrapper example

## Test plan

- [ ] User with 2FA enabled logs in via an exempted OAuth provider — no 2FA prompt, login completes normally
- [ ] User with 2FA enabled logs in via a non-exempted OAuth provider — 2FA prompt still shown
- [ ] User with 2FA enabled logs in directly (username + password) — 2FA prompt unaffected
- [ ] Multiple providers can be exempted via chained `->disable()` calls