### PR TITLE
[2.x] feat: add extender to disable 2FA for specific OAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,39 @@ TODO
 
 ##### Admin user list status icon
 ![userlist](https://github.com/imorland/flarum-ext-twofactor/assets/16573496/9c1a58c9-919b-4552-ad1f-f022a5240f17)
+
+## Extensibility
+
+### Disabling 2FA for specific OAuth providers
+
+If you are building an extension that integrates with `fof/oauth` and want certain providers to bypass the 2FA challenge entirely, use the `TwoFactor` extender in your extension's `extend.php`. Wrap it in a `Conditional` so it only activates when `ianm/twofactor` is enabled:
+
+```php
+use Flarum\Extend\Conditional;
+use IanM\TwoFactor\Extend\TwoFactor;
+
+return [
+    // ...
+    (new Conditional())
+        ->whenExtensionEnabled('ianm-twofactor', fn () => [
+            (new TwoFactor())->disable('my-oauth-provider'),
+        ]),
+];
+```
+
+The provider name must match the string identifier used when registering the provider with `fof/oauth` (e.g. `'github'`, `'google'`, `'discord'`). Multiple providers can be chained:
+
+```php
+(new Conditional())
+    ->whenExtensionEnabled('ianm-twofactor', fn () => [
+        (new TwoFactor())
+            ->disable('github')
+            ->disable('google'),
+    ]),
+```
+
+> **Note:** This only bypasses the OAuth 2FA interception. Users who log in directly (username + password) are unaffected and will still be required to complete 2FA if it is enabled on their account.
+
 ## Links
 
 - [Packagist](https://packagist.org/packages/ianm/twofactor)

--- a/src/Extend/TwoFactor.php
+++ b/src/Extend/TwoFactor.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\TwoFactor\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
+use Illuminate\Contracts\Container\Container;
+
+class TwoFactor implements ExtenderInterface
+{
+    private array $disabledProviders = [];
+
+    public function disable(string $provider): static
+    {
+        $this->disabledProviders[] = $provider;
+
+        return $this;
+    }
+
+    public function extend(Container $container, ?Extension $extension = null): void
+    {
+        $container->extend(
+            DisabledProviderRegistry::class,
+            function (DisabledProviderRegistry $registry) {
+                foreach ($this->disabledProviders as $provider) {
+                    $registry->disable($provider);
+                }
+
+                return $registry;
+            }
+        );
+    }
+}

--- a/src/OAuth/DisabledProviderRegistry.php
+++ b/src/OAuth/DisabledProviderRegistry.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace IanM\TwoFactor\OAuth;
+
+class DisabledProviderRegistry
+{
+    private array $disabled = [];
+
+    public function disable(string $provider): void
+    {
+        $this->disabled[] = $provider;
+    }
+
+    public function isDisabled(string $provider): bool
+    {
+        return in_array($provider, $this->disabled, true);
+    }
+}

--- a/src/OAuth/TwoFactorOAuthListener.php
+++ b/src/OAuth/TwoFactorOAuthListener.php
@@ -16,6 +16,7 @@ use Flarum\User\User;
 use FoF\OAuth\Controllers\AbstractOAuthController;
 use FoF\OAuth\Events\OAuthLoginSuccessful;
 use IanM\TwoFactor\Contracts\TotpInterface;
+use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
 use IanM\TwoFactor\Trait\TwoFactorAuthenticationTrait;
 use Illuminate\Contracts\Cache\Store as CacheStore;
 
@@ -30,7 +31,8 @@ class TwoFactorOAuthListener
 
     public function __construct(
         protected TotpInterface $totp,
-        protected CacheStore $cache
+        protected CacheStore $cache,
+        protected DisabledProviderRegistry $disabledProviders,
     ) {
     }
 
@@ -53,7 +55,7 @@ class TwoFactorOAuthListener
 
         $user = $this->getUserFromProvider($event->providerName, $event->identifier);
 
-        if (! $user || ! $this->twoFactorActive($user)) {
+        if (! $user || $this->disabledProviders->isDisabled($event->providerName) || ! $this->twoFactorActive($user)) {
             return;
         }
 

--- a/src/OAuth/TwoFactorOAuthListener.php
+++ b/src/OAuth/TwoFactorOAuthListener.php
@@ -16,7 +16,6 @@ use Flarum\User\User;
 use FoF\OAuth\Controllers\AbstractOAuthController;
 use FoF\OAuth\Events\OAuthLoginSuccessful;
 use IanM\TwoFactor\Contracts\TotpInterface;
-use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
 use IanM\TwoFactor\Trait\TwoFactorAuthenticationTrait;
 use Illuminate\Contracts\Cache\Store as CacheStore;
 

--- a/src/Provider/TwoFactorServiceProvider.php
+++ b/src/Provider/TwoFactorServiceProvider.php
@@ -13,6 +13,7 @@ namespace IanM\TwoFactor\Provider;
 
 use Flarum\Foundation\AbstractServiceProvider;
 use IanM\TwoFactor\Contracts\TotpInterface;
+use IanM\TwoFactor\OAuth\DisabledProviderRegistry;
 use IanM\TwoFactor\Services\BackupCodeGenerator;
 use IanM\TwoFactor\Services\OtpWrapper;
 use IanM\TwoFactor\Services\QrCodeGenerator;
@@ -26,6 +27,7 @@ class TwoFactorServiceProvider extends AbstractServiceProvider
         $this->container->bind(QrCodeGenerator::class);
         $this->container->bind(BackupCodeGenerator::class);
         $this->container->bind(TwoFactorRestrictor::class);
+        $this->container->singleton(DisabledProviderRegistry::class);
     }
 
     public function boot(): void


### PR DESCRIPTION
## Summary

- Adds `IanM\TwoFactor\Extend\TwoFactor` extender with a `->disable(string $provider)` method
- Adds `DisabledProviderRegistry` singleton to hold the list of exempt providers
- `TwoFactorOAuthListener` now checks the registry and skips the 2FA interception for exempt providers
- Documents usage in README with `Conditional` wrapper example

## Notes

Same feature as #46 but targeting 2.x. The bypass point differs: on 1.x it was `TwoFactorOAuthCheck` (a callable); on 2.x the check lives in `TwoFactorOAuthListener::handle()` (an event listener), so that's where the early return is added.

## Test plan

- [ ] User with 2FA enabled logs in via an exempted OAuth provider — no 2FA prompt, login completes normally
- [ ] User with 2FA enabled logs in via a non-exempted OAuth provider — 2FA prompt still shown
- [ ] User with 2FA enabled logs in directly (username + password) — 2FA prompt unaffected
- [ ] Multiple providers can be exempted via chained `->disable()` calls