### PR TITLE
[1.x] refactor: remove 2FA enforcement for admin group

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This extension requires a minimum of PHP 8.1, due to a 3rd party library constra
 
 ## Features
 
-- Enforces `admin` accounts to have 2FA enabled for increased security
 - Configure which additional user groups should also be enforced
 - Supports all common authentication apps
 - Protects `login`, `forgot password` endpoints

--- a/js/src/admin/extendEditGroupModal.js
+++ b/js/src/admin/extendEditGroupModal.js
@@ -3,7 +3,6 @@ import { extend } from 'flarum/common/extend';
 import EditGroupModal from 'flarum/admin/components/EditGroupModal';
 import Switch from 'flarum/common/components/Switch';
 import Stream from 'flarum/common/utils/Stream';
-import Group from 'flarum/common/models/Group';
 
 export default function extendEditGroupModal() {
   extend(EditGroupModal.prototype, 'oninit', function (vnode) {
@@ -11,22 +10,13 @@ export default function extendEditGroupModal() {
   });
 
   extend(EditGroupModal.prototype, 'fields', function (items) {
-    const isAdmin = this.group.id() === Group.ADMINISTRATOR_ID;
     items.add(
       '2fa',
       <div className="Form-group">
-        {isAdmin ? (
-          <p>
-            {app.translator.trans('ianm-twofactor.admin.edit_group.admin_2fa_help', {
-              adminName: this.group.nameSingular(),
-            })}
-          </p>
-        ) : (
-          <Switch state={this.requires2FA()} onchange={this.requires2FA}>
-            {app.translator.trans('ianm-twofactor.admin.edit_group.2fa_label')}
-          </Switch>
-        )}
-        {!isAdmin && <p className="helpText">{app.translator.trans('ianm-twofactor.admin.edit_group.2fa_help')}</p>}
+        <Switch state={this.requires2FA()} onchange={this.requires2FA}>
+          {app.translator.trans('ianm-twofactor.admin.edit_group.2fa_label')}
+        </Switch>
+        <p className="helpText">{app.translator.trans('ianm-twofactor.admin.edit_group.2fa_help')}</p>
       </div>,
       10
     );

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -3,7 +3,6 @@ ianm-twofactor:
     edit_group:
       2fa_label: 2FA required
       2fa_help: Require members of this group to enable Two-Factor Authentication (2FA) for their account.
-      admin_2fa_help: "{adminName} members must always have 2FA enabled."
     permissions:
       see_two_factor_status_label: View 2FA status of other users
       manage_others_label: Manage 2FA for other users

--- a/migrations/2026_05_11_000000_remove_admin_2fa_enforcement.php
+++ b/migrations/2026_05_11_000000_remove_admin_2fa_enforcement.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of ianm/twofactor.
+ *
+ * Copyright (c) 2023 IanM.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Group\Group;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        // Remove 2FA enforcement from admin group to make it configurable like other groups
+        $connection = $schema->getConnection();
+        $connection->table('groups')->where('id', Group::ADMINISTRATOR_ID)->update(['tfa_required' => false]);
+    },
+
+    'down' => function (Builder $schema) {
+        // Not doing anything but `down` has to be defined
+    }
+];

--- a/src/Model/TwoFactor.php
+++ b/src/Model/TwoFactor.php
@@ -79,7 +79,7 @@ class TwoFactor extends AbstractModel
      */
     public static function guardedGroups(): array
     {
-        return [Group::ADMINISTRATOR_ID, Group::GUEST_ID];
+        return [Group::GUEST_ID];
     }
 
     /**

--- a/tests/integration/api/CurrentUserSerializerTest.php
+++ b/tests/integration/api/CurrentUserSerializerTest.php
@@ -93,7 +93,7 @@ class CurrentUserSerializerTest extends TestCase
         $json = json_decode($response->getBody()->getContents(), true);
 
         $this->assertTrue($json['data']['attributes']['twoFactorEnabled']);
-        $this->assertFalse($json['data']['attributes']['canDisable2FA']);
+        $this->assertTrue($json['data']['attributes']['canDisable2FA']);
         $this->assertFalse($json['data']['attributes']['mustEnable2FA']);
         $this->assertEquals(2, $json['data']['attributes']['backupCodesRemaining']);
     }


### PR DESCRIPTION
### Summary
This change removes the hardcoded requirement that admin group members must have 2FA enabled, making the admin group behave the same as other user groups regarding 2FA settings.

The original implementation enforced 2FA for admin users as a security best practice. However, I think this should be a configurable choice rather than a hardcoded requirement. Admin should have the flexibility to decide their own security policies.

### Changes Made
**Backend**: Removed `Group::ADMINISTRATOR_ID` from `TwoFactor::guardedGroups()` in `src/Model/TwoFactor.php`
**Frontend**: Removed special admin group handling in `js/src/admin/extendEditGroupModal.js` - admin group now shows the same 2FA toggle as other groups
**Migration**: Added migration to remove `tfa_required = true` from existing admin groups
**Test**: The test `two_factor_is_enabled_for_given_user_and_returns_correct_properties()` now correctly asserts that admin users can disable 2FA (canDisable2FA = true) instead of being blocked (canDisable2FA = false).